### PR TITLE
Ensure Drupal rules take precedence for SCSS files

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,10 +3,17 @@ module.exports = {
   overrides: [
     {
       files: ["*.scss", "**/*.scss"],
+
+      // stylelint-config-standard-scss and stylelint-config-drupal disagree
+      // about some rules, so stylelint-config-drupal is extended after
+      // stylelint-config-standard-scss to ensure that its rules take
+      // precedence.
       extends: [
         "stylelint-config-standard-scss",
+        "stylelint-config-drupal",
         "stylelint-config-prettier-scss",
       ],
+
       rules: {
         // This rule finds false positives in multi-line comments that use // and
         // have more than one paragraph...

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inveniem/stylelint-config",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Inveniem's reusable Stylelint configuration",
   "main": "index.js",
   "author": "John Karahalis <john.karahalis@inveniem.com>",


### PR DESCRIPTION
This fixes an issue where some rules from stylelint-config-drupal were being overridden by rules from stylelint-config-standard-scss for SCSS files.